### PR TITLE
Add GitHub Action to build kernel image

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,83 @@
+---
+name: Build Kernel and TWRP
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  kernel:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential ccache bc bison flex libssl-dev \
+            libncurses5-dev lzop zip cpio fakeroot
+
+      - name: Setup Toolchain
+        run: |
+          mkdir -p Toolchain/aarch64-linux-android-4.9
+          wget https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/a7bb6f39cd99b2fb26ecc2d3cb984d18cd259d24.tar.gz -O toolchain.tar.gz
+          tar -xzf toolchain.tar.gz -C Toolchain/aarch64-linux-android-4.9
+
+      - name: Build kernel
+        run: |
+          cd build_kernel
+          chmod +x build_kernel.sh build_boot.sh ramdisk_fix_permissions.sh
+          ./build_kernel.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-image
+          path: |
+            build_kernel/Image
+            build_kernel/boot.img
+            build_kernel/*.zip
+            build_kernel/*.tar.*
+
+  twrp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential ccache bc bison flex libssl-dev \
+            libncurses5-dev lzop zip cpio fakeroot
+
+      - name: Toolchain & Build TWRP
+        run: |
+          cd build_twrp
+          mkdir -p ../Toolchain/aarch64-linux-android-4.9
+          wget https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+archive/a7bb6f39cd99b2fb26ecc2d3cb984d18cd259d24.tar.gz -O ../Toolchain/aarch64-linux-android.tar.gz
+          tar -xzf ../Toolchain/aarch64-linux-android.tar.gz -C ../Toolchain/aarch64-linux-android-4.9
+          ls -l ../Toolchain/aarch64-linux-android-4.9/bin
+          chmod +x build_kernel.sh
+          ln -sf compile_recovery.sh build_recovery.sh
+          ./build_kernel.sh
+
+      - name: Upload TWRP artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: twrp-build
+          path: |
+            build_twrp/ManhIT_TWRP-3.0.0-1_SC-05G.*
+            build_twrp/recovery.img
+

--- a/.github/workflows/build_twrp.yml
+++ b/.github/workflows/build_twrp.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Toolchain & Build (all in build_twrp dir)
         run: |
-          cd ..
           cd build_twrp
           # Download and extract toolchain (relative to repo root)
           mkdir -p ../Toolchain/aarch64-linux-android-4.9


### PR DESCRIPTION
## Summary
- automate kernel image build in CI using provided toolchain
- run build_twrp after kernel build and upload artifacts
- fix path in build_twrp workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688522e725d0832da452126f243de1a4